### PR TITLE
Fix ERB file detection

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/vitallium/zed-stimulus"
 
 [language_servers.stimulus]
 name = "Stimulus"
-languages = ["HTML", "ERB", "PHP"]
+languages = ["HTML", "HTML/ERB", "PHP"]


### PR DESCRIPTION
In one of the updates related to Ruby support in Zed, the id for .erb files got changed to `HTML/ERB` causing the LSP not to run in these. Updating the language id in `extension.toml` file fixes the issue.